### PR TITLE
Add build properties to be able to pass configuration options to the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Import the default build.xml to let Phing know about the Security Checker task:
     <import file="vendor/bitexpert/phing-securitychecker/build.xml" />
 ```
 
+If you imported the default build.xml, you are able to define the lock file
+path as well the as the webservice endpoint by defining two properties
+in your main build.xml file:
+
+```xml
+    <property name="securitychecker.lockfile" value="composer.lock" />
+    <property name="securitychecker.endpoint" value="https://security.sensiolabs.org/check_lock" />
+```
+
 Or define the securitychecker task on your own:
 
 ```xml

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,21 @@
     <taskdef name="securitychecker" classpath="${phing.dir.securitychecker}/src" classname="bitExpert\Phing\SecurityChecker\SecurityCheckerTask" />
 
     <target name="security:check">
-        <securitychecker lockfile="${phing.dir}/composer.lock" />
+        <if>
+            <or>
+                <not>
+                    <isset property="securitychecker.lockfile" />
+                </not>
+                <equals arg1="${securitychecker.lockfile}" arg2="" trim="true" />
+            </or>
+            <then>
+                <property name="securitychecker.lockfile" value="${phing.dir}/composer.lock" override="true" />
+            </then>
+        </if>
+
+        <echo msg="Lockfile: ${securitychecker.lockfile}"/>
+        <echo msg="Endpoint: ${securitychecker.endpoint}"/>
+
+        <securitychecker lockfile="${securitychecker.lockfile}" endpoint="${securitychecker.endpoint}" />
     </target>
 </project>


### PR DESCRIPTION
When relying on the default build.xml file it was not possible to overwrite the lock file path or the webservice endpoint. With this PR is it now possible to define 2 properties in the projects' build file that get picked up by the default build.xml shipped with this package. This allows customization without the need to copy & paste Phing code.