### PR TITLE
Remove VersionEye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A Phing task for interacting with the SensioLabs Security Advisories Checker to 
 dependencies with known security vulnerabilities.
 
 [![Build Status](https://travis-ci.org/bitExpert/phing-securitychecker.svg?branch=master)](https://travis-ci.org/bitExpert/phing-securitychecker)
-[![Dependency Status](https://www.versioneye.com/user/projects/57d9b5111b70a7003f25a522/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57d9b5111b70a7003f25a522)
 [![Coverage Status](https://coveralls.io/repos/github/bitExpert/phing-securitychecker/badge.svg?branch=master)](https://coveralls.io/github/bitExpert/phing-securitychecker?branch=master)
 
 Installation


### PR DESCRIPTION
Remove the VersionEye badge from the readme file due to versioneye shutting down end of 2017.

More information about the VersionEye sunset process:
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/
